### PR TITLE
Feature: Skip List by passing profile name

### DIFF
--- a/index.js
+++ b/index.js
@@ -58,11 +58,8 @@ const readAwsProfiles = () => {
 };
 
 const writeToConfig = (answers) => {
-  const profileChoice =
-    answers.profile === defaultProfileChoice ? "" : answers.profile;
-
   return new Promise((resolve, reject) => {
-    fs.writeFile(`${homeDir}/.awsp`, profileChoice, { flag: "w" }, (err) => {
+    fs.writeFile(`${homeDir}/.awsp`, answers.profile, { flag: "w" }, (err) => {
       if (err) {
         reject(err);
       } else {

--- a/run.sh
+++ b/run.sh
@@ -1,11 +1,14 @@
 #!/bin/sh
 
-AWS_PROFILE="$AWS_PROFILE" _awsp_prompt
+if [ $# -eq 0 ]; then
+  AWS_PROFILE="$AWS_PROFILE" _awsp_prompt
+  selected_profile="$(cat $HOME/.awsp)"
+else
+  selected_profile="$@"
+  echo "$selected_profile" > $HOME/.awsp
+fi
 
-selected_profile="$(cat ~/.awsp)"
-
-if [ -z "$selected_profile" ]
-then
+if [ -z "$selected_profile" ] || [ "$selected_profile" == "default" ]; then
   unset AWS_PROFILE
 else
   export AWS_PROFILE="$selected_profile"


### PR DESCRIPTION
If an argument is passed, awsp will not be called and instead that profile will just be set, allowing quick changing.

Example: `awsp production` will skip the list and just switch to `production`.