### PR TITLE
get config file path from aws_config_file env var

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,11 +2,13 @@
 
 const fs = require("fs");
 const inquirer = require("inquirer");
-inquirer.registerPrompt('search-list', require('inquirer-search-list'));
+inquirer.registerPrompt("search-list", require("inquirer-search-list"));
 
 console.log("AWS Profile Switcher Plus");
 
 const homeDir = process.env["HOME"];
+const configFilePath =
+  process.env["AWS_CONFIG_FILE"] || `${homeDir}/.aws/config`;
 const profileRegex = /\[profile .*]/g;
 const bracketsRemovalRegx = /(\[profile )|(\])/g;
 const defaultProfileChoice = "default";
@@ -47,7 +49,7 @@ const promptProfileChoice = (data) => {
 
 const readAwsProfiles = () => {
   return new Promise((resolve, reject) => {
-    fs.readFile(`${homeDir}/.aws/config`, "utf8", (err, data) => {
+    fs.readFile(configFilePath, "utf8", (err, data) => {
       if (err) {
         reject(err);
       } else {


### PR DESCRIPTION
resolves #4 
It reads the `AWS_CONFIG_FILE ` variable from the environment and reads the configs from that location.
if the variable is not set then it defaults to `$HOME/.aws/config`