### PR TITLE
Remove postinstall to support Windows

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,12 @@
 {
   "name": "awsp-plus",
-  "version": "1.0.1",
+  "version": "1.1.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "1.0.1",
+      "name": "awsp-plus",
+      "version": "1.1.1",
       "hasInstallScript": true,
       "license": "ISC",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,10 +7,9 @@
     "": {
       "name": "awsp-plus",
       "version": "1.1.1",
-      "hasInstallScript": true,
       "license": "ISC",
       "dependencies": {
-        "inquirer": "^8.1.5",
+        "inquirer": "^8.2.0",
         "inquirer-search-list": "^1.2.6"
       },
       "bin": {
@@ -280,9 +279,9 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
     "node_modules/inquirer": {
-      "version": "8.1.5",
-      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-8.1.5.tgz",
-      "integrity": "sha512-G6/9xUqmt/r+UvufSyrPpt84NYwhKZ9jLsgMbQzlx804XErNupor8WQdBnBRrXmBfTPpuwf1sV+ss2ovjgdXIg==",
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-8.2.0.tgz",
+      "integrity": "sha512-0crLweprevJ02tTuA6ThpoAERAGyVILC4sS74uib58Xf/zSr1/ZWtmm7D5CI+bSQEaA04f0K7idaHpQbSWgiVQ==",
       "dependencies": {
         "ansi-escapes": "^4.2.1",
         "chalk": "^4.1.1",
@@ -956,9 +955,9 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
     "inquirer": {
-      "version": "8.1.5",
-      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-8.1.5.tgz",
-      "integrity": "sha512-G6/9xUqmt/r+UvufSyrPpt84NYwhKZ9jLsgMbQzlx804XErNupor8WQdBnBRrXmBfTPpuwf1sV+ss2ovjgdXIg==",
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-8.2.0.tgz",
+      "integrity": "sha512-0crLweprevJ02tTuA6ThpoAERAGyVILC4sS74uib58Xf/zSr1/ZWtmm7D5CI+bSQEaA04f0K7idaHpQbSWgiVQ==",
       "requires": {
         "ansi-escapes": "^4.2.1",
         "chalk": "^4.1.1",

--- a/package.json
+++ b/package.json
@@ -12,8 +12,7 @@
   ],
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
-    "postinstall": "./postinstall.sh"
+    "test": "echo \"Error: no test specified\" && exit 1"
   },
   "repository": {
     "type": "git",
@@ -27,7 +26,7 @@
     "_awspp": "run.sh"
   },
   "dependencies": {
-    "inquirer": "^8.1.5",
+    "inquirer": "^8.2.0",
     "inquirer-search-list": "^1.2.6"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "awsp-plus",
   "description": "Easily switch between and manage AWS CLI profiles",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "author": "Abyss (https://abyss.dev)",
   "license": "ISC",
   "homepage": "https://github.com/abyss/awsp-plus",

--- a/postinstall.sh
+++ b/postinstall.sh
@@ -1,5 +1,0 @@
-#!/bin/sh
-
-echo "Add the following to your .bashrc or .zshrc config"
-echo '    alias awsp="source _awspp"'
-echo ""


### PR DESCRIPTION
Postinstall seems to do nothing with global installs anyways, and this blocks installation on Windows because failure.